### PR TITLE
Add missing json dependency and possibility to specify tags for successfull or failed translations

### DIFF
--- a/Ruby/translation.nuixscript/Translators/libre_translate.rb
+++ b/Ruby/translation.nuixscript/Translators/libre_translate.rb
@@ -1,5 +1,6 @@
 require 'uri'
 require 'net/http'
+require 'json'
 
 # Class for translating items using Libre Translate API
 class LibreTranslate < NuixTranslator


### PR DESCRIPTION
On some version of Nuix workstation the json dependency is missing and an error occurs

Additionally it is now possible to specify which tags should be used for tagging failed or successfull translations