### PR TITLE
Libretranslate: add timeout for getting text, add truncate function to "fix" missing timeouts

### DIFF
--- a/Ruby/translation.nuixscript/Translators/libre_translate.rb
+++ b/Ruby/translation.nuixscript/Translators/libre_translate.rb
@@ -29,7 +29,7 @@ class LibreTranslate < NuixTranslator
     'et' => 'Estonian',
     'fi' => 'Finnish',
     'fr' => 'French',
-    'gl' => 'Gallician',
+    'gl' => 'Galician',
     'de' => 'German',
     'el' => 'Greek',
     'he' => 'Hebrew',

--- a/Ruby/translation.nuixscript/Translators/libre_translate.rb
+++ b/Ruby/translation.nuixscript/Translators/libre_translate.rb
@@ -159,7 +159,7 @@ class LibreTranslate < NuixTranslator
   # @param item [Item] a Nuix item
   def translate(item)
     @progress.setMainStatusAndLogIt('Translating')
-## Timeout für Text abholen mit entsprechender Nachricht und Tagging  
+## Timeout for retrieval of text with message and tagging  
   begin
 		text = Timeout::timeout(@settings['http_timeout'].to_i) do
 			get_original_text(item)

--- a/Ruby/translation.nuixscript/Translators/libre_translate.rb
+++ b/Ruby/translation.nuixscript/Translators/libre_translate.rb
@@ -16,14 +16,20 @@ class LibreTranslate < NuixTranslator
     'sq' => 'Albanian',
     'ar' => 'Arabic',
     'az' => 'Azerbaijani',
+    'eu' => 'Basque',
+    'bg' => 'Bulgarian',
+    'bn' => 'Bengali',
+    'ca' => 'Catalan',
     'zh' => 'Chinese',
+    'zt' => 'Chinese (traditional)',
     'cs' => 'Czech',
     'da' => 'Danish',
     'nl' => 'Dutch',
     'eo' => 'Esperanto',
+    'et' => 'Estonian',
     'fi' => 'Finnish',
     'fr' => 'French',
-    'gl' => 'Galician',
+    'gl' => 'Gallician',
     'de' => 'German',
     'el' => 'Greek',
     'he' => 'Hebrew',
@@ -33,28 +39,34 @@ class LibreTranslate < NuixTranslator
     'ga' => 'Irish',
     'it' => 'Italian',
     'ja' => 'Japanese',
-    'kab' => 'Kabyle',
     'ko' => 'Korean',
-    'nb' => 'Norwegian Bokmål',
-    'oc' => 'Occitan',
+    'lv' => 'Latvian',
+    'lt' => 'Lithuanian',
+    'ms' => 'Malay',    
+    'nb' => 'Norwegian',
     'fa' => 'Persian',
     'pl' => 'Polish',
     'pt' => 'Portuguese',
+    'ro' => 'Romanian',
     'ru' => 'Russian',
     'sk' => 'Slovak',
+    'sl' => 'Slovenian',
     'es' => 'Spanish',
     'sv' => 'Swedish',
-    'zgh' => 'Tamazight-Standard Moroccan',
+    'tl' => 'Tagalog',
+    'th' => 'Thai',
     'tr' => 'Turkish',
     'uk' => 'Ukrainian',
-    'vi' => 'Vietnamese'
+    'ur' => 'Urdu',
   }.freeze
 
   # Creates a new NuixTranslator using Libre Translate API.
   def initialize
     super(NAME, LANGUAGES)
-	@input.setSize(500,350)
+	@input.setSize(500,400)
     @main_tab.appendTextField('api_url', 'API URL', '')
+    @main_tab.appendTextField('char_limit', 'Character Limit', '10000') ## Field for character limit
+    @main_tab.appendComboBox('limit_behavior', 'Limit Behavior', ['Ignore', 'Skip', 'Truncate']) ## Menu for character limit
     add_translation_options
     add_translation
     add_translation_tagging
@@ -72,7 +84,7 @@ class LibreTranslate < NuixTranslator
   end
 
   def add_translation_options
-    @main_tab.appendTextField('http_timeout', 'HTTP Timeout (sec.)', 30.to_s)
+    @main_tab.appendTextField('http_timeout', 'Timeout (sec.)', 30.to_s)
     @main_tab.appendComboBox('translation_language_from', 'Source Language', @langs.values)
   end
 
@@ -147,23 +159,57 @@ class LibreTranslate < NuixTranslator
   # @param item [Item] a Nuix item
   def translate(item)
     @progress.setMainStatusAndLogIt('Translating')
-    text = get_original_text(item)
-    return nil if text.empty?
-
-    item.removeTag("Translations|failure")
-    item.removeTag("Translations|success")
-
-    translated = libre_translate(text)
-    if translated.nil?
-      item.addTag("Translations|failure") if @settings['tag_items_failure']
-      @progress.logMessage("No response received! Please try again later")
-      return nil 
-    end
-
-    item.addTag("Translations|success")
-
-    super(item, translated) unless translated.nil? || translated.empty?
+## Timeout für Text abholen mit entsprechender Nachricht und Tagging  
+  begin
+		text = Timeout::timeout(@settings['http_timeout'].to_i) do
+			get_original_text(item)
+		end
+  rescue Timeout::Error
+		@progress.logMessage("Getting original Text took too long")
+		item.addTag("Translations|failuregettingtext")
+		return nil
   end
+  
+  return nil if text.empty?
+
+  char_limit = @settings['char_limit'].to_i ##provides the character limit from the input and converts it to integer
+  limit_behavior = @settings['limit_behavior'] ##provides the limit behavior from the input
+
+##removes all tags, adds the right ones
+##returns nil if too long and skip is selected, truncates text to limit if too long and truncate is selected, else translates
+  item.removeTag("Translations|failure")
+  item.removeTag("Translations|success")
+  item.removeTag("Translations|skipped")
+  item.removeTag("Translations|truncated")
+  item.removeTag("Translations|failuregettingtext")
+  t_l = text.length.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse
+  c_l = char_limit.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse
+  if text.length > char_limit
+    case limit_behavior
+    when 'Skip'
+      item.addTag("Translations|skipped")
+      @progress.logMessage("Text length " + t_l + " > Limit " + c_l + " -> Skipped")
+      return nil
+    when 'Truncate'
+      text = text[0..char_limit]
+      item.addTag("Translations|truncated")
+      @progress.logMessage("Text length " + t_l + " > Limit " + c_l + " -> Truncated")
+    end
+  end
+
+  translated = libre_translate(text)
+  if translated.nil?
+    item.addTag("Translations|failure") if @settings['tag_items_failure']
+    @progress.logMessage("No response received! Please try again later")
+    return nil 
+  end
+
+  item.addTag("Translations|success")
+
+  super(item, translated) unless translated.nil? || translated.empty?
+end
+
+
 
   # Validation function for input.
   #  Checks for API URL.


### PR DESCRIPTION
I added a few features and have been using it in production for more than a year.

The first is a (hardcoded) timeout for getting the text. Before I added this, very large files (usually carved items) would completely freeze the translation. Now they get skipped and tagged "Failure getting text".

The second is a configurable text length limit. You can specify a number of characters, e.g. 10.000. This limit can either be ignored, files longer than it can be skipped (and tagged accordingly), or they can be truncated to only translate the first 10.000 characters (and be tagged accordingly). This has proven to be very valuable to speed up processing times and is usually enough to judge, if the file is worth using additional resources on.
I also would recommend to always set the timeout high enough (e.g. 300 seconds for 10.000 characters), so that there is no congestion issue in the libretranslate container.

I also updated the list of supported languages, although that may already be outdated again.